### PR TITLE
Update ember-source@2.15.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,79 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@glimmer/compiler": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.22.3.tgz",
-      "integrity": "sha1-Ou+USEYK8dMgqCQjMjSYpv84oMY=",
-      "dev": true,
-      "requires": {
-        "@glimmer/syntax": "0.22.3",
-        "@glimmer/util": "0.22.3",
-        "@glimmer/wire-format": "0.22.3",
-        "simple-html-tokenizer": "0.3.0"
-      },
-      "dependencies": {
-        "simple-html-tokenizer": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
-          "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
-          "dev": true
-        }
-      }
-    },
     "@glimmer/di": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.2.0.tgz",
       "integrity": "sha1-c7/Upu5BSKgL8JLopdKbysnUzn4=",
       "dev": true
-    },
-    "@glimmer/interfaces": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.22.3.tgz",
-      "integrity": "sha1-HC4yia5Bp1DwyN3MZFKbnpDdpgQ=",
-      "dev": true,
-      "requires": {
-        "@glimmer/wire-format": "0.22.3"
-      }
-    },
-    "@glimmer/node": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.22.3.tgz",
-      "integrity": "sha1-/zPupuZRR6IMG9HwX9xKbDWVxUw=",
-      "dev": true,
-      "requires": {
-        "@glimmer/runtime": "0.22.3",
-        "simple-dom": "0.3.2"
-      }
-    },
-    "@glimmer/object": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/object/-/object-0.22.3.tgz",
-      "integrity": "sha1-H8n9dGXH0S5bkkZK1AA4tZXejtA=",
-      "dev": true,
-      "requires": {
-        "@glimmer/object-reference": "0.22.3",
-        "@glimmer/util": "0.22.3"
-      }
-    },
-    "@glimmer/object-reference": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/object-reference/-/object-reference-0.22.3.tgz",
-      "integrity": "sha1-MdtoyJEjJMY1CbHvgyE/etTvMSs=",
-      "dev": true,
-      "requires": {
-        "@glimmer/reference": "0.22.3",
-        "@glimmer/util": "0.22.3"
-      }
-    },
-    "@glimmer/reference": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.22.3.tgz",
-      "integrity": "sha1-by74zZf+dW2J/vdfjDx5ADUCoqk=",
-      "dev": true,
-      "requires": {
-        "@glimmer/util": "0.22.3"
-      }
     },
     "@glimmer/resolver": {
       "version": "0.4.1",
@@ -85,53 +17,6 @@
       "dev": true,
       "requires": {
         "@glimmer/di": "0.2.0"
-      }
-    },
-    "@glimmer/runtime": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.22.3.tgz",
-      "integrity": "sha1-uMso78nMhsQG7plvXCz2cwYg1AQ=",
-      "dev": true,
-      "requires": {
-        "@glimmer/interfaces": "0.22.3",
-        "@glimmer/object": "0.22.3",
-        "@glimmer/object-reference": "0.22.3",
-        "@glimmer/reference": "0.22.3",
-        "@glimmer/util": "0.22.3",
-        "@glimmer/wire-format": "0.22.3"
-      }
-    },
-    "@glimmer/syntax": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.22.3.tgz",
-      "integrity": "sha1-hSjRkyS/f5IPXP0xkl5FLlF4G0Q=",
-      "dev": true,
-      "requires": {
-        "handlebars": "4.0.10",
-        "simple-html-tokenizer": "0.3.0"
-      },
-      "dependencies": {
-        "simple-html-tokenizer": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
-          "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
-          "dev": true
-        }
-      }
-    },
-    "@glimmer/util": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.22.3.tgz",
-      "integrity": "sha1-gnL1CQXRu5BO43Horeg/13m1FQg=",
-      "dev": true
-    },
-    "@glimmer/wire-format": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.22.3.tgz",
-      "integrity": "sha1-GbIm2bk7pu5URy2f+x1I58DYCg0=",
-      "dev": true,
-      "requires": {
-        "@glimmer/util": "0.22.3"
       }
     },
     "abbrev": {
@@ -179,22 +64,6 @@
       "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic=",
       "dev": true
     },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
-    "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
-    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -210,7 +79,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
       "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-      "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2"
       }
@@ -218,8 +86,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -230,14 +97,12 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "ansicolors": {
       "version": "0.2.1",
@@ -349,8 +214,7 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -406,6 +270,16 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "ast-types": {
       "version": "0.9.6",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
@@ -416,7 +290,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -425,7 +298,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
       "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "heimdalljs": "0.2.5",
@@ -446,17 +318,30 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
-      "dev": true,
       "requires": {
         "async": "2.5.0",
         "debug": "2.6.9"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -467,7 +352,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.0",
@@ -494,7 +378,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
@@ -509,8 +392,7 @@
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         }
       }
     },
@@ -518,7 +400,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -529,7 +410,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -541,7 +421,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -553,7 +432,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -564,7 +442,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -577,7 +454,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -587,7 +463,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -597,7 +472,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -607,7 +481,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -618,7 +491,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -631,7 +503,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-messages": "6.23.0",
@@ -645,7 +516,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -655,7 +525,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -664,7 +533,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -673,7 +541,6 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
       "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
-      "dev": true,
       "requires": {
         "semver": "5.4.1"
       }
@@ -682,7 +549,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz",
       "integrity": "sha1-uq8m3Ovi7R3hIAIbxCvin1IEl7M=",
-      "dev": true,
       "requires": {
         "ember-rfc176-data": "0.2.7"
       }
@@ -708,26 +574,22 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -738,7 +600,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -747,7 +608,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -756,7 +616,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
@@ -769,7 +628,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
       "requires": {
         "babel-helper-define-map": "6.26.0",
         "babel-helper-function-name": "6.24.1",
@@ -786,7 +644,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -796,7 +653,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -805,7 +661,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -815,7 +670,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -824,7 +678,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -835,7 +688,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -844,7 +696,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -855,7 +706,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -867,7 +717,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -878,7 +727,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -889,7 +737,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "6.24.1",
         "babel-runtime": "6.26.0"
@@ -899,7 +746,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
@@ -913,7 +759,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -923,7 +768,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -932,7 +776,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -943,7 +786,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -952,7 +794,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -961,7 +802,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -972,7 +812,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -983,7 +822,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
       "requires": {
         "regenerator-transform": "0.10.1"
       }
@@ -992,7 +830,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -1002,7 +839,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "core-js": "2.5.1",
@@ -1012,8 +848,7 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
       }
     },
@@ -1021,7 +856,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
       "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
-      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1059,7 +893,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1074,7 +907,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
@@ -1084,7 +916,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -1097,7 +928,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -1114,7 +944,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -1137,8 +966,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "backbone": {
       "version": "1.3.3",
@@ -1158,8 +986,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -1179,6 +1006,15 @@
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
@@ -1197,14 +1033,12 @@
     "binaryextensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
-      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8=",
-      "dev": true
+      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8="
     },
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
-      "dev": true
+      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
     },
     "blob": {
       "version": "0.0.4",
@@ -1230,6 +1064,14 @@
         "safe-json-parse": "1.0.1"
       }
     },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
     "bower-config": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
@@ -1253,7 +1095,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1296,7 +1137,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
       "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "broccoli-funnel": "1.2.0",
@@ -1363,7 +1203,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.2.2.tgz",
       "integrity": "sha1-hv/cUmButZC6n2uJTF7HoBb1t7k=",
-      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "broccoli-plugin": "1.3.0",
@@ -1383,7 +1222,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
@@ -1431,7 +1269,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.3.tgz",
       "integrity": "sha512-YqpMH2QPHNtGoauVOj715dqDfurJa9O2and1UuxfzzGpM3A9mBrXeeLdWpTt8hj/Y8u8WaG/L1UBZYffPvTHVw==",
-      "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
         "fs-tree-diff": "0.5.6",
@@ -1495,7 +1332,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
       "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-      "dev": true,
       "requires": {
         "array-equal": "1.0.0",
         "blank-object": "1.0.2",
@@ -1523,32 +1359,15 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
-      "dev": true,
       "requires": {
         "glob": "5.0.15",
         "mkdirp": "0.5.1"
-      }
-    },
-    "broccoli-lint-eslint": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-3.3.1.tgz",
-      "integrity": "sha1-NcZ1VGpaetjzMZ7dcy46rYyiQd4=",
-      "dev": true,
-      "requires": {
-        "aot-test-generators": "0.1.0",
-        "broccoli-concat": "3.2.2",
-        "broccoli-persistent-filter": "1.4.3",
-        "eslint": "3.19.0",
-        "json-stable-stringify": "1.0.1",
-        "lodash.defaultsdeep": "4.6.0",
-        "md5-hex": "2.0.0"
       }
     },
     "broccoli-merge-trees": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
       "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-      "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
         "can-symlink": "1.0.0",
@@ -1574,7 +1393,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
-      "dev": true,
       "requires": {
         "async-disk-cache": "1.3.3",
         "async-promise-queue": "1.0.4",
@@ -1595,7 +1413,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
-      "dev": true,
       "requires": {
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
@@ -1658,8 +1475,7 @@
     "broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-      "dev": true
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
     },
     "broccoli-sri-hash": {
       "version": "2.1.2",
@@ -1726,7 +1542,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
-      "dev": true,
       "requires": {
         "broccoli-debug": "0.6.3",
         "broccoli-funnel": "1.2.0",
@@ -1748,7 +1563,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0"
@@ -1795,7 +1609,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
       "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000735",
         "electron-to-chromium": "1.3.21"
@@ -1862,7 +1675,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
       "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
-      "dev": true,
       "requires": {
         "tmp": "0.0.28"
       }
@@ -1870,8 +1682,7 @@
     "caniuse-lite": {
       "version": "1.0.30000735",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000735.tgz",
-      "integrity": "sha1-qrRAFu8kPiFe9D/RND79IpMIQvg=",
-      "dev": true
+      "integrity": "sha1-qrRAFu8kPiFe9D/RND79IpMIQvg="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -1892,6 +1703,11 @@
         "redeyed": "1.0.1"
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -1906,7 +1722,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -2054,14 +1869,12 @@
     "clone": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-      "dev": true
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2073,7 +1886,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2081,14 +1893,21 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.8.1",
@@ -2155,8 +1974,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -2257,14 +2075,12 @@
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-      "dev": true
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -2281,8 +2097,7 @@
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-      "dev": true
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-object": {
       "version": "3.1.5",
@@ -2327,8 +2142,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -2339,6 +2153,24 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "crypto-random-string": {
@@ -2362,11 +2194,18 @@
       "integrity": "sha1-lxS0ct6CoYQ94vuptodpOMq0TGg=",
       "dev": true
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -2375,6 +2214,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
       "dev": true
     },
     "deep-is": {
@@ -2397,6 +2242,11 @@
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -2429,7 +2279,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -2459,11 +2308,19 @@
         "is-obj": "1.0.1"
       }
     },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
     "editions": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
-      "dev": true
+      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2474,8 +2331,7 @@
     "electron-to-chromium": {
       "version": "1.3.21",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz",
-      "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI=",
-      "dev": true
+      "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI="
     },
     "ember-ajax": {
       "version": "3.0.0",
@@ -2487,12 +2343,12 @@
       }
     },
     "ember-cli": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.14.2.tgz",
-      "integrity": "sha1-8sjHXUhs5sxrf/vCLr74syuyQrc=",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.15.1.tgz",
+      "integrity": "sha1-dzrdPMGOUGjxxfQ6d1RO+icS5Hs=",
       "dev": true,
       "requires": {
-        "amd-name-resolver": "0.0.6",
+        "amd-name-resolver": "0.0.7",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "bower-config": "1.4.1",
         "bower-endpoint-parser": "0.2.2",
@@ -2517,9 +2373,9 @@
         "console-ui": "1.0.3",
         "core-object": "3.1.5",
         "dag-map": "2.0.2",
+        "deep-freeze": "0.0.1",
         "diff": "3.3.1",
         "ember-cli-broccoli-sane-watcher": "2.0.4",
-        "ember-cli-get-component-path-option": "1.0.0",
         "ember-cli-is-package-missing": "1.0.0",
         "ember-cli-legacy-blueprints": "0.1.5",
         "ember-cli-lodash-subset": "1.0.12",
@@ -2528,8 +2384,7 @@
         "ember-cli-string-utils": "1.1.0",
         "ember-try": "0.2.17",
         "ensure-posix-path": "1.0.2",
-        "escape-string-regexp": "1.0.5",
-        "execa": "0.6.3",
+        "execa": "0.7.0",
         "exists-sync": "0.0.4",
         "exit": "0.1.2",
         "express": "4.15.4",
@@ -2546,7 +2401,7 @@
         "heimdalljs-logger": "0.1.9",
         "http-proxy": "1.16.2",
         "inflection": "1.12.0",
-        "is-git-url": "0.2.3",
+        "is-git-url": "1.0.0",
         "isbinaryfile": "3.0.2",
         "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
@@ -2579,15 +2434,6 @@
         "yam": "0.0.22"
       },
       "dependencies": {
-        "amd-name-resolver": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz",
-          "integrity": "sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
-        },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
@@ -2596,6 +2442,21 @@
           "requires": {
             "broccoli-plugin": "1.3.0",
             "merge-trees": "1.0.1"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "glob": {
@@ -2611,6 +2472,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "is-git-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
+          "integrity": "sha1-U/aEzRQyhbUsMkS05vKCU1J69ms=",
+          "dev": true
         }
       }
     },
@@ -2628,7 +2495,6 @@
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz",
       "integrity": "sha1-6sJ4WWT0dD9MgVzVPGKI8AzAh9c=",
-      "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-debug-macros": "0.1.11",
@@ -2658,92 +2524,403 @@
       }
     },
     "ember-cli-dependency-checker": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-1.4.0.tgz",
-      "integrity": "sha1-KxP5d+HuqEP8GiGgAb5spdTvGUI=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-2.0.1.tgz",
+      "integrity": "sha512-eL7P3nCmekZ7pR1M+lTjZm2FnxTRQ14eVDbcGIFeku5v5GrCSSLYUB4wqSBlkhCmakOdmgXzAnHIpQGmk4WBuw==",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
-        "is-git-url": "0.2.3",
-        "semver": "4.3.6"
+        "chalk": "1.1.3",
+        "is-git-url": "1.0.0",
+        "semver": "5.4.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
-          }
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+        "is-git-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
+          "integrity": "sha1-U/aEzRQyhbUsMkS05vKCU1J69ms=",
           "dev": true
         }
       }
     },
     "ember-cli-eslint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-eslint/-/ember-cli-eslint-3.1.0.tgz",
-      "integrity": "sha1-jZ4qhnZUg1rBskhY2RF+FD+lS9Q=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-eslint/-/ember-cli-eslint-4.2.0.tgz",
+      "integrity": "sha1-Pst7Dmf9rdHmjqugX7r/sDvNeGQ=",
       "dev": true,
       "requires": {
-        "broccoli-lint-eslint": "3.3.1",
-        "ember-cli-version-checker": "1.3.1",
+        "broccoli-lint-eslint": "4.1.0",
+        "ember-cli-version-checker": "2.0.0",
         "rsvp": "3.6.2",
         "walk-sync": "0.3.2"
       },
       "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "broccoli-lint-eslint": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-4.1.0.tgz",
+          "integrity": "sha1-3M+hFQ3GJAfNZv1WphknPFR5oQ4=",
+          "dev": true,
+          "requires": {
+            "aot-test-generators": "0.1.0",
+            "broccoli-concat": "3.2.2",
+            "broccoli-persistent-filter": "1.4.3",
+            "eslint": "4.8.0",
+            "json-stable-stringify": "1.0.1",
+            "lodash.defaultsdeep": "4.6.0",
+            "md5-hex": "2.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "eslint": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
+          "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.2.3",
+            "babel-code-frame": "6.26.0",
+            "chalk": "2.1.0",
+            "concat-stream": "1.6.0",
+            "cross-spawn": "5.1.0",
+            "debug": "3.1.0",
+            "doctrine": "2.0.0",
+            "eslint-scope": "3.7.1",
+            "espree": "3.5.1",
+            "esquery": "1.0.0",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "functional-red-black-tree": "1.0.1",
+            "glob": "7.1.2",
+            "globals": "9.18.0",
+            "ignore": "3.3.5",
+            "imurmurhash": "0.1.4",
+            "inquirer": "3.3.0",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.10.0",
+            "json-stable-stringify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "7.0.0",
+            "progress": "2.0.0",
+            "require-uncached": "1.0.3",
+            "semver": "5.4.1",
+            "strip-ansi": "4.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "4.0.2",
+            "text-table": "0.2.0"
+          }
+        },
+        "external-editor": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+          "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.19",
+            "jschardet": "1.5.1",
+            "tmp": "0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.1.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.0.5",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "5.2.3",
+            "ajv-keywords": "2.1.0",
+            "chalk": "2.1.0",
+            "lodash": "4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "2.1.1"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        }
+      }
+    },
+    "ember-cli-fastboot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-1.0.5.tgz",
+      "integrity": "sha512-uTgzk2DWkjU58srEAWXiKMRRe+/cXMxLmCfOk5U4Dq3mC7/xezRThqsa+6+Bj4QIfDmchdWTlPk3BXw7tPkGKw==",
+      "requires": {
+        "broccoli-concat": "3.2.2",
+        "broccoli-funnel": "1.2.0",
+        "broccoli-merge-trees": "2.0.0",
+        "broccoli-plugin": "1.3.0",
+        "chalk": "2.1.0",
+        "ember-cli-babel": "6.8.2",
+        "ember-cli-version-checker": "2.0.0",
+        "fastboot": "1.1.0",
+        "fastboot-express-middleware": "1.0.0",
+        "fs-extra": "4.0.2",
+        "json-stable-stringify": "1.0.1",
+        "lodash.uniq": "4.5.0",
+        "md5-hex": "2.0.0",
+        "silent-error": "1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "merge-trees": "1.0.1"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -2773,14 +2950,15 @@
       }
     },
     "ember-cli-htmlbars-inline-precompile": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.4.4.tgz",
-      "integrity": "sha1-JKdhcVJjDWSgR+VTty4AljpPjXM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz",
+      "integrity": "sha1-W1RPZk1dmRHwjNl5xfcNjLDKKt0=",
       "dev": true,
       "requires": {
         "babel-plugin-htmlbars-inline-precompile": "0.2.3",
         "ember-cli-version-checker": "2.0.0",
         "hash-for-dep": "1.2.0",
+        "heimdalljs-logger": "0.1.9",
         "silent-error": "1.1.0"
       }
     },
@@ -3023,7 +3201,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz",
       "integrity": "sha1-4ffY5M3NdSrDXxYR5Nqog220xMc=",
-      "dev": true,
       "requires": {
         "resolve": "1.4.0",
         "semver": "5.4.1"
@@ -3210,8 +3387,7 @@
     "ember-rfc176-data": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
-      "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA==",
-      "dev": true
+      "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -3244,25 +3420,27 @@
       }
     },
     "ember-source": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.14.1.tgz",
-      "integrity": "sha1-Sr8LTJFvLai/MXNJ30dQkF335ig=",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.15.1.tgz",
+      "integrity": "sha1-oBY/dMI4l+l0vgkWw/I/z9Qt20o=",
       "dev": true,
       "requires": {
-        "@glimmer/compiler": "0.22.3",
-        "@glimmer/node": "0.22.3",
-        "@glimmer/reference": "0.22.3",
-        "@glimmer/runtime": "0.22.3",
-        "@glimmer/util": "0.22.3",
+        "@glimmer/compiler": "0.25.3",
+        "@glimmer/node": "0.25.3",
+        "@glimmer/reference": "0.25.3",
+        "@glimmer/runtime": "0.25.3",
+        "@glimmer/util": "0.25.3",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-get-component-path-option": "1.0.0",
+        "ember-cli-is-package-missing": "1.0.0",
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-path-utils": "1.0.0",
         "ember-cli-string-utils": "1.1.0",
         "ember-cli-test-info": "1.0.0",
         "ember-cli-valid-component-name": "1.0.0",
         "ember-cli-version-checker": "1.3.1",
+        "ember-router-generator": "1.2.3",
         "handlebars": "4.0.10",
         "jquery": "3.2.1",
         "resolve": "1.4.0",
@@ -3271,6 +3449,124 @@
         "simple-html-tokenizer": "0.4.1"
       },
       "dependencies": {
+        "@glimmer/compiler": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.25.3.tgz",
+          "integrity": "sha1-JesGOU87ocH65a8lyc996ywR704=",
+          "dev": true,
+          "requires": {
+            "@glimmer/interfaces": "0.25.3",
+            "@glimmer/syntax": "0.25.3",
+            "@glimmer/util": "0.25.3",
+            "@glimmer/wire-format": "0.25.3",
+            "simple-html-tokenizer": "0.3.0"
+          },
+          "dependencies": {
+            "simple-html-tokenizer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
+              "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
+              "dev": true
+            }
+          }
+        },
+        "@glimmer/interfaces": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.25.3.tgz",
+          "integrity": "sha1-jEYLKK1aF+qhcS5qp7jrtJc4w48=",
+          "dev": true,
+          "requires": {
+            "@glimmer/wire-format": "0.25.3"
+          }
+        },
+        "@glimmer/node": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.25.3.tgz",
+          "integrity": "sha1-MBgo6EVb4UHVOEsBmA7ZvgKYQFk=",
+          "dev": true,
+          "requires": {
+            "@glimmer/runtime": "0.25.3",
+            "simple-dom": "0.3.2"
+          }
+        },
+        "@glimmer/object": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/object/-/object-0.25.3.tgz",
+          "integrity": "sha1-RR6yCNrboe3pwMA4qQ3+MmN0k/4=",
+          "dev": true,
+          "requires": {
+            "@glimmer/object-reference": "0.25.3",
+            "@glimmer/util": "0.25.3"
+          }
+        },
+        "@glimmer/object-reference": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/object-reference/-/object-reference-0.25.3.tgz",
+          "integrity": "sha1-4NH6h0+RLn0SMtSH/NIJbmsxtiA=",
+          "dev": true,
+          "requires": {
+            "@glimmer/reference": "0.25.3",
+            "@glimmer/util": "0.25.3"
+          }
+        },
+        "@glimmer/reference": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.25.3.tgz",
+          "integrity": "sha1-oJ3cOXvuAiPec+pQRKMEowk1EE8=",
+          "dev": true,
+          "requires": {
+            "@glimmer/util": "0.25.3"
+          }
+        },
+        "@glimmer/runtime": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.25.3.tgz",
+          "integrity": "sha1-riEBoeTeMzDQjyCAbBgyfb+obXg=",
+          "dev": true,
+          "requires": {
+            "@glimmer/interfaces": "0.25.3",
+            "@glimmer/object": "0.25.3",
+            "@glimmer/object-reference": "0.25.3",
+            "@glimmer/reference": "0.25.3",
+            "@glimmer/util": "0.25.3",
+            "@glimmer/wire-format": "0.25.3"
+          }
+        },
+        "@glimmer/syntax": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.25.3.tgz",
+          "integrity": "sha1-s/ilm+5hb9YAMB13jeO2Sb93A24=",
+          "dev": true,
+          "requires": {
+            "@glimmer/interfaces": "0.25.3",
+            "@glimmer/util": "0.25.3",
+            "handlebars": "4.0.10",
+            "simple-html-tokenizer": "0.3.0"
+          },
+          "dependencies": {
+            "simple-html-tokenizer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
+              "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
+              "dev": true
+            }
+          }
+        },
+        "@glimmer/util": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.25.3.tgz",
+          "integrity": "sha1-fO33KUcTe1GWWMi+NNDVllzr46E=",
+          "dev": true
+        },
+        "@glimmer/wire-format": {
+          "version": "0.25.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.25.3.tgz",
+          "integrity": "sha1-BGaSs6JqMKSYcSJmzQvbR9dxDzc=",
+          "dev": true,
+          "requires": {
+            "@glimmer/util": "0.25.3"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
@@ -3538,8 +3834,7 @@
     "ensure-posix-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
-      "dev": true
+      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI="
     },
     "entities": {
       "version": "1.1.1",
@@ -3615,18 +3910,6 @@
         "es5-ext": "0.10.30"
       }
     },
-    "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3636,108 +3919,16 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
-      }
-    },
-    "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.4",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
-        },
-        "run-async": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "espree": {
@@ -3784,8 +3975,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -3824,21 +4014,6 @@
         "merge": "1.2.0"
       }
     },
-    "execa": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
-      "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
-    },
     "exists-stat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/exists-stat/-/exists-stat-1.0.0.tgz",
@@ -3848,8 +4023,7 @@
     "exists-sync": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
-      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
-      "dev": true
+      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk="
     },
     "exit": {
       "version": "0.1.2",
@@ -3940,8 +4114,7 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
       "version": "1.1.1",
@@ -3974,6 +4147,16 @@
         "is-extglob": "1.0.0"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -3984,7 +4167,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
-      "dev": true,
       "requires": {
         "blank-object": "1.0.2"
       }
@@ -3993,7 +4175,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.2.3.tgz",
       "integrity": "sha1-IvFOktc543kgM0N27IQzv2deqgQ=",
-      "dev": true,
       "requires": {
         "chalk": "0.5.1",
         "fs-extra": "0.30.0",
@@ -4009,20 +4190,17 @@
         "ansi-regex": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-          "dev": true
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
         },
         "ansi-styles": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-          "dev": true
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
         },
         "chalk": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true,
           "requires": {
             "ansi-styles": "1.1.0",
             "escape-string-regexp": "1.0.5",
@@ -4035,7 +4213,6 @@
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
@@ -4048,7 +4225,6 @@
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true,
           "requires": {
             "ansi-regex": "0.2.1"
           }
@@ -4057,7 +4233,6 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -4066,7 +4241,6 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true,
           "requires": {
             "ansi-regex": "0.2.1"
           }
@@ -4074,8 +4248,101 @@
         "supports-color": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-          "dev": true
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+        }
+      }
+    },
+    "fastboot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-1.1.0.tgz",
+      "integrity": "sha512-mhr5jhJ1BWtFaFV2qPEy7eJxo6WROvrmio6DpHytbHxvD6qFgjGijN4k0VMNahjtIrewOB2Z0+nuUSJb7oUlHQ==",
+      "requires": {
+        "chalk": "2.1.0",
+        "cookie": "0.3.1",
+        "debug": "3.1.0",
+        "exists-sync": "0.0.4",
+        "najax": "1.0.3",
+        "rsvp": "3.6.2",
+        "simple-dom": "1.2.0",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "simple-dom": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/simple-dom/-/simple-dom-1.2.0.tgz",
+          "integrity": "sha512-s14UTsUhG9hYDW5T5rcfJUgXPKVX1so7nM9sdK24Na3qx+cEgzfGQFJsfbJ8bwEGs5BwyfJnp6DhQ3/31qmhow=="
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "fastboot-express-middleware": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-1.0.0.tgz",
+      "integrity": "sha1-xo/ifANxF606ldhJ5Bja4gjgtQM=",
+      "requires": {
+        "chalk": "2.1.0",
+        "fastboot": "1.1.0",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -4160,8 +4427,7 @@
     "find-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-1.1.0.tgz",
-      "integrity": "sha1-UwB8ec0wBA1oFteUWOiDfVxXBe8=",
-      "dev": true
+      "integrity": "sha1-UwB8ec0wBA1oFteUWOiDfVxXBe8="
     },
     "find-up": {
       "version": "2.1.0",
@@ -4232,6 +4498,21 @@
         "for-in": "1.0.2"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -4276,7 +4557,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz",
       "integrity": "sha1-NCZldJ6NykBoALZyJoyPUHPz5iM=",
-      "dev": true,
       "requires": {
         "heimdalljs-logger": "0.1.9",
         "object-assign": "4.1.1",
@@ -4287,7 +4567,12 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gauge": {
@@ -4304,21 +4589,6 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "wide-align": "1.1.2"
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
       }
     },
     "get-caller-file": {
@@ -4338,6 +4608,14 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "git-repo-info": {
       "version": "1.4.1",
@@ -4366,7 +4644,6 @@
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
       "requires": {
         "inflight": "1.0.6",
         "inherits": "2.0.3",
@@ -4419,8 +4696,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
@@ -4455,8 +4731,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -4499,11 +4774,37 @@
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.2.3",
+        "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -4534,8 +4835,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -4547,7 +4847,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.0.tgz",
       "integrity": "sha512-nTAMv4FEqSmV/u/LnPnw0YZJP0Qve7lLv5D8q5Zu441gI/lBZCq3BwnoZjlOn/HBLoK9DgyY+qVhCzxb1dAAiA==",
-      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "heimdalljs": "0.2.5",
@@ -4555,11 +4854,21 @@
         "resolve": "1.4.0"
       }
     },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
+      }
+    },
     "heimdalljs": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
-      "dev": true,
       "requires": {
         "rsvp": "3.2.1"
       },
@@ -4567,8 +4876,7 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
         }
       }
     },
@@ -4592,17 +4900,20 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "heimdalljs": "0.2.5"
       }
     },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -4651,6 +4962,16 @@
         "requires-port": "1.0.0"
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -4685,7 +5006,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -4694,8 +5014,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.4",
@@ -4746,17 +5065,10 @@
         "through": "2.3.8"
       }
     },
-    "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
-      "dev": true
-    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -4813,7 +5125,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -4827,12 +5138,6 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-git-url": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-0.2.3.tgz",
-      "integrity": "sha1-RFIA1vvW2gKPteAUQNmvyT88y2Q=",
-      "dev": true
-    },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -4840,18 +5145,6 @@
       "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
-      }
-    },
-    "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
       }
     },
     "is-number": {
@@ -4911,12 +5204,6 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -4940,6 +5227,11 @@
       "requires": {
         "core-util-is": "1.0.2"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -4980,11 +5272,15 @@
         "isarray": "1.0.0"
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "istextorbinary": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
-      "dev": true,
       "requires": {
         "binaryextensions": "2.0.0",
         "editions": "1.3.3",
@@ -4997,6 +5293,11 @@
       "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
       "dev": true
     },
+    "jquery-deferred": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jquery-deferred/-/jquery-deferred-0.3.1.tgz",
+      "integrity": "sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U="
+    },
     "js-reporters": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.0.tgz",
@@ -5006,8 +5307,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
@@ -5027,20 +5327,45 @@
         }
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jschardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "dev": true
+    },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
@@ -5051,14 +5376,12 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -5066,14 +5389,18 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -5088,7 +5415,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -5154,8 +5480,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -5184,7 +5509,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
       "integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
-      "dev": true,
       "requires": {
         "lodash._basecreate": "2.3.0",
         "lodash._setbinddata": "2.3.0",
@@ -5201,7 +5525,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
       "integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
-      "dev": true,
       "requires": {
         "lodash._renative": "2.3.0",
         "lodash.isobject": "2.3.0",
@@ -5212,7 +5535,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
       "integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
-      "dev": true,
       "requires": {
         "lodash._setbinddata": "2.3.0",
         "lodash.bind": "2.3.0",
@@ -5224,7 +5546,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
       "integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
-      "dev": true,
       "requires": {
         "lodash._basecreate": "2.3.0",
         "lodash._setbinddata": "2.3.0",
@@ -5263,7 +5584,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
       "integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
-      "dev": true,
       "requires": {
         "lodash._basebind": "2.3.0",
         "lodash._basecreatewrapper": "2.3.0",
@@ -5274,7 +5594,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz",
       "integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
-      "dev": true,
       "requires": {
         "lodash._htmlescapes": "2.3.0"
       }
@@ -5282,8 +5601,7 @@
     "lodash._escapestringchar": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz",
-      "integrity": "sha1-zOc65g/G2lXSv4oGecI8orqxSfw=",
-      "dev": true
+      "integrity": "sha1-zOc65g/G2lXSv4oGecI8orqxSfw="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -5294,8 +5612,7 @@
     "lodash._htmlescapes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.3.0.tgz",
-      "integrity": "sha1-HKmIY8rfH6HYLITzXzHkBVagTzo=",
-      "dev": true
+      "integrity": "sha1-HKmIY8rfH6HYLITzXzHkBVagTzo="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
@@ -5306,26 +5623,22 @@
     "lodash._objecttypes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
-      "integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4=",
-      "dev": true
+      "integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4="
     },
     "lodash._reinterpolate": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.3.0.tgz",
-      "integrity": "sha1-A+6dhcDlXL1ZDXFgiilb3aURKOw=",
-      "dev": true
+      "integrity": "sha1-A+6dhcDlXL1ZDXFgiilb3aURKOw="
     },
     "lodash._renative": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-      "integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M=",
-      "dev": true
+      "integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M="
     },
     "lodash._reunescapedhtml": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz",
       "integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
-      "dev": true,
       "requires": {
         "lodash._htmlescapes": "2.3.0",
         "lodash.keys": "2.3.0"
@@ -5335,7 +5648,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
       "integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
-      "dev": true,
       "requires": {
         "lodash._renative": "2.3.0",
         "lodash.noop": "2.3.0"
@@ -5345,7 +5657,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
       "integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "2.3.0"
       }
@@ -5353,8 +5664,7 @@
     "lodash._slice": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
-      "integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw=",
-      "dev": true
+      "integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw="
     },
     "lodash.assign": {
       "version": "3.2.0",
@@ -5390,7 +5700,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
       "integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
-      "dev": true,
       "requires": {
         "lodash._createwrapper": "2.3.0",
         "lodash._renative": "2.3.0",
@@ -5416,7 +5725,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
       "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "2.3.0",
         "lodash.keys": "2.3.0"
@@ -5425,14 +5733,12 @@
     "lodash.defaultsdeep": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
-      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
-      "dev": true
+      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E="
     },
     "lodash.escape": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.3.0.tgz",
       "integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
-      "dev": true,
       "requires": {
         "lodash._escapehtmlchar": "2.3.0",
         "lodash._reunescapedhtml": "2.3.0",
@@ -5459,7 +5765,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
       "integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
-      "dev": true,
       "requires": {
         "lodash._basecreatecallback": "2.3.0",
         "lodash.forown": "2.3.0"
@@ -5469,7 +5774,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
       "integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
-      "dev": true,
       "requires": {
         "lodash._basecreatecallback": "2.3.0",
         "lodash._objecttypes": "2.3.0",
@@ -5479,8 +5783,7 @@
     "lodash.identity": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
-      "integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0=",
-      "dev": true
+      "integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -5497,14 +5800,12 @@
     "lodash.isfunction": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz",
-      "integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc=",
-      "dev": true
+      "integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc="
     },
     "lodash.isobject": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
       "integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "2.3.0"
       }
@@ -5513,7 +5814,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
       "integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
-      "dev": true,
       "requires": {
         "lodash._renative": "2.3.0",
         "lodash._shimkeys": "2.3.0",
@@ -5523,20 +5823,17 @@
     "lodash.merge": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
-      "dev": true
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "lodash.noop": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
-      "integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw=",
-      "dev": true
+      "integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw="
     },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
-      "dev": true
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -5548,7 +5845,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
       "integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
-      "dev": true,
       "requires": {
         "lodash._renative": "2.3.0"
       }
@@ -5584,7 +5880,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz",
       "integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "2.3.0",
         "lodash.escape": "2.3.0"
@@ -5593,8 +5888,7 @@
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-      "dev": true
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lodash.uniqby": {
       "version": "4.7.0",
@@ -5606,7 +5900,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.3.0.tgz",
       "integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
-      "dev": true,
       "requires": {
         "lodash.keys": "2.3.0"
       }
@@ -5621,7 +5914,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -5695,7 +5987,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-      "dev": true,
       "requires": {
         "minimatch": "3.0.4"
       }
@@ -5704,7 +5995,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-      "dev": true,
       "requires": {
         "md5-o-matic": "0.1.1"
       }
@@ -5712,8 +6002,7 @@
     "md5-o-matic": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-      "dev": true
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -5731,7 +6020,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.2.tgz",
       "integrity": "sha1-Jz/3d6tg/sWZsRY1UlUoLMosUMI=",
-      "dev": true,
       "requires": {
         "readable-stream": "1.0.34"
       }
@@ -5752,7 +6040,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-      "dev": true,
       "requires": {
         "can-symlink": "1.0.0",
         "fs-tree-diff": "0.5.6",
@@ -5798,23 +6085,26 @@
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -5822,14 +6112,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -5837,8 +6125,7 @@
     "mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
-      "dev": true
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
     },
     "morgan": {
       "version": "1.8.2",
@@ -5873,8 +6160,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mustache": {
       "version": "2.3.0",
@@ -5887,6 +6173,16 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
       "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
       "dev": true
+    },
+    "najax": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/najax/-/najax-1.0.3.tgz",
+      "integrity": "sha1-ERRfTZEERupmHYq3/O9T9q0WSuU=",
+      "requires": {
+        "jquery-deferred": "0.3.1",
+        "lodash.defaultsdeep": "4.6.0",
+        "qs": "6.5.0"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5992,14 +6288,17 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -6036,7 +6335,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -6100,8 +6398,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-shim": {
       "version": "0.1.3",
@@ -6112,8 +6409,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.4",
@@ -6206,8 +6502,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -6224,20 +6519,23 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
-      "dev": true
+      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -6259,12 +6557,6 @@
       "requires": {
         "pinkie": "2.0.4"
       }
-    },
-    "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-      "dev": true
     },
     "portfinder": {
       "version": "1.0.13",
@@ -6306,8 +6598,7 @@
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
-      "dev": true
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -6324,17 +6615,10 @@
         "node-modules-path": "1.0.1"
       }
     },
-    "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true
-    },
     "promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
-      "dev": true,
       "requires": {
         "rsvp": "3.6.2"
       }
@@ -6355,17 +6639,20 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
     "qs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
-      "dev": true
+      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
     },
     "quick-temp": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
-      "dev": true,
       "requires": {
         "mktemp": "0.4.0",
         "rimraf": "2.6.2",
@@ -6492,7 +6779,6 @@
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6503,8 +6789,7 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
@@ -6546,25 +6831,6 @@
         }
       }
     },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      },
-      "dependencies": {
-        "mute-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-          "dev": true
-        }
-      }
-    },
     "recast": {
       "version": "0.11.23",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
@@ -6575,15 +6841,6 @@
         "esprima": "3.1.3",
         "private": "0.1.7",
         "source-map": "0.5.7"
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.4.0"
       }
     },
     "redeyed": {
@@ -6606,20 +6863,17 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-      "dev": true
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-      "dev": true
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -6639,7 +6893,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
       "requires": {
         "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
@@ -6649,14 +6902,12 @@
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       }
@@ -6683,9 +6934,44 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        }
       }
     },
     "require-uncached": {
@@ -6708,7 +6994,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-      "dev": true,
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -6752,7 +7037,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       },
@@ -6761,7 +7045,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -6785,8 +7068,7 @@
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -6809,11 +7091,19 @@
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "3.1.2"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-json-parse": {
       "version": "1.0.1",
@@ -6847,8 +7137,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "0.15.4",
@@ -6933,33 +7222,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
-        "rechoir": "0.6.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
-      }
-    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -6976,7 +7238,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9"
       }
@@ -6996,14 +7257,15 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
-    "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+    "sntp": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "socket.io": {
       "version": "1.6.0",
@@ -7165,14 +7427,12 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
       "requires": {
         "source-map": "0.5.7"
       }
@@ -7180,14 +7440,12 @@
     "source-map-url": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
-      "dev": true
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
     },
     "sourcemap-validator": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.0.5.tgz",
       "integrity": "sha1-+blg9IxkaeKIoZrzBfAF2j3B3zo=",
-      "dev": true,
       "requires": {
         "jsesc": "0.3.0",
         "lodash.foreach": "2.3.0",
@@ -7198,14 +7456,12 @@
         "jsesc": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
-          "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=",
-          "dev": true
+          "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI="
         },
         "lodash.template": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.3.0.tgz",
           "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
-          "dev": true,
           "requires": {
             "lodash._escapestringchar": "2.3.0",
             "lodash._reinterpolate": "2.3.0",
@@ -7220,7 +7476,6 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -7246,8 +7501,7 @@
     "sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
-      "dev": true
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
     "sri-toolbox": {
       "version": "0.2.0",
@@ -7255,16 +7509,25 @@
       "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-template": {
@@ -7284,11 +7547,20 @@
         "strip-ansi": "3.0.1"
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -7329,61 +7601,12 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symlink-or-copy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
-      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
-      "dev": true
-    },
-    "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
+      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
     },
     "tap-parser": {
       "version": "5.4.0",
@@ -7472,8 +7695,7 @@
     "textextensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz",
-      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M=",
-      "dev": true
+      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M="
     },
     "through": {
       "version": "2.3.8",
@@ -7499,7 +7721,6 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -7519,14 +7740,20 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tree-sync": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "fs-tree-diff": "0.5.6",
@@ -7539,7 +7766,6 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
             "matcher-collection": "1.0.5"
@@ -7550,14 +7776,27 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -7616,7 +7855,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.1.1",
         "util-deprecate": "1.0.2"
@@ -7634,8 +7872,7 @@
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -7652,26 +7889,15 @@
         "os-homedir": "1.0.2"
       }
     },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
     "username-sync": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
-      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8=",
-      "dev": true
+      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.0",
@@ -7682,8 +7908,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
@@ -7700,11 +7925,20 @@
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
       "dev": true
     },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-      "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2",
         "matcher-collection": "1.0.5"
@@ -7775,7 +8009,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.2.4.tgz",
       "integrity": "sha512-gE7StiPAOM6318V3EzlR0sFgedAF11PjDZ1xt3SpbuF/vTTDFX2XEnkbFUNqhIHBEKzBDFLPgJSIXyJKP4wZBQ==",
-      "dev": true,
       "requires": {
         "object-assign": "4.1.1"
       }
@@ -7783,8 +8016,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.15.0",
+    "ember-source": "~2.15.1",
     "ember-welcome-page": "^3.0.0",
     "loader.js": "^4.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,9 +2281,9 @@ ember-runtime-enumerable-includes-polyfill@^2.0.0:
     ember-cli-babel "^6.0.0"
     ember-cli-version-checker "^1.1.6"
 
-ember-source@~2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.15.0.tgz#901cbe3abee09292372b06f6aa8dd342683be2d5"
+ember-source@~2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.15.1.tgz#a0163f74c23897e974be0916c3f23fcfd42ddb4a"
   dependencies:
     "@glimmer/compiler" "^0.25.3"
     "@glimmer/node" "^0.25.3"


### PR DESCRIPTION
Confirmed that visiting /error-route renders the error template.